### PR TITLE
Symbol Exporting and Install Rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,15 @@ if (BUILD_LAS)
   list(APPEND SOURCES vtkLASReader.h vtkLASReader.cxx)
 endif()
 
-
 find_package(VTK NO_MODULE REQUIRED COMPONENTS ${VTK_REQUIRED_COMPONENTS})
 include(${VTK_USE_FILE})
+
+# include export header modules so that we can easily control symbol exporting
+# VTK Map is setup by default not to export symbols unless explicitly stated.
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+include(GenerateExportHeader)
+
 
 set (SOURCES
 	  vtkGeoJSONReader.cxx
@@ -48,8 +54,8 @@ set (SOURCES
 set (HEADERS
     vtkGeoJSONReader.h
     vtkGeoJSONFeature.h
+    ${CMAKE_CURRENT_BINARY_DIR}/vtkdatasetreaders_export.h
     )
-
 
 if(BUILD_POSTGRES)
   list(APPEND SOURCES vtkPostgreSQLDatabase.cxx)
@@ -61,11 +67,14 @@ if (BUILD_LAS)
   list(APPEND HEADERS vtkLASReader.h)
 endif()
 
-
 add_library(vtkDataSetReaders ${SOURCES})
+
 target_link_libraries(vtkDataSetReaders
                       LINK_PUBLIC
                       ${VTK_LIBRARIES})
+
+target_include_directories(vtkDataSetReaders
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 if(BUILD_LAS)
   target_link_libraries(vtkDataSetReaders LINK_PUBLIC ${libLAS_LIBRARIES} )
@@ -87,6 +96,8 @@ else( )
                         )
 endif()
 
+#setup export header
+generate_export_header(vtkDataSetReaders)
 
 #install all the headers and the library
 install(TARGETS vtkDataSetReaders

--- a/vtkGeoJSONFeature.h
+++ b/vtkGeoJSONFeature.h
@@ -24,6 +24,8 @@
 #include "vtkDataObject.h"
 #include "vtk_jsoncpp.h" // For json parser
 
+#include "vtkdatasetreaders_export.h"
+
 class vtkPolyData;
 class vtkStdString;
 
@@ -36,7 +38,7 @@ class vtkStdString;
 #define MULTI_POLYGON           "MultiPolygon"
 #define GEOMETRY_COLLECTION     "GeometryCollection"
 
-class vtkGeoJSONFeature : public vtkDataObject
+class VTKDATASETREADERS_EXPORT vtkGeoJSONFeature : public vtkDataObject
 {
 public:
   static vtkGeoJSONFeature *New();

--- a/vtkGeoJSONReader.h
+++ b/vtkGeoJSONReader.h
@@ -24,9 +24,11 @@
 #include "vtkPolyDataAlgorithm.h"
 #include "vtk_jsoncpp.h" // For json parser
 
+#include "vtkdatasetreaders_export.h"
+
 class vtkPolyData;
 
-class vtkGeoJSONReader: public vtkPolyDataAlgorithm
+class VTKDATASETREADERS_EXPORT vtkGeoJSONReader: public vtkPolyDataAlgorithm
 {
 public:
   static vtkGeoJSONReader* New();

--- a/vtkLASReader.h
+++ b/vtkLASReader.h
@@ -12,6 +12,8 @@
 #include <vtkInformationVector.h>
 #include <vtkObjectFactory.h>
 
+#include "vtkdatasetreaders_export.h"
+
 //libLAS Includes
 #include <liblas/liblas.hpp>
 
@@ -19,7 +21,7 @@
 #include <fstream>
 #include <iostream>
 
-class vtkLASReader: public vtkPolyDataAlgorithm
+class VTKDATASETREADERS_EXPORT vtkLASReader: public vtkPolyDataAlgorithm
 {
 public:
   static vtkLASReader* New();

--- a/vtkPostGISQuery.h
+++ b/vtkPostGISQuery.h
@@ -3,11 +3,13 @@
 
 #include <vtkPostgreSQLQuery.h>
 
+#include "vtkdatasetreaders_export.h"
+
 #define GeoJSON 1
 
 class vtkPolyData;
 
-class vtkPostGISQuery : public vtkPostgreSQLQuery
+class VTKDATASETREADERS_EXPORT vtkPostGISQuery : public vtkPostgreSQLQuery
 {
 public:
   static vtkPostGISQuery *New();


### PR DESCRIPTION
I have added Symbol Exporting and Install Rules.

The desire for these changes is for vtkDataSetReaders to be contained within a superbuild on windows.
