### PR TITLE
Add option to GeoJSON reader to store serialized "properties" node

### DIFF
--- a/Testing/TestGeoJSON.cxx
+++ b/Testing/TestGeoJSON.cxx
@@ -35,6 +35,7 @@ int TestGeoJSON(int argc, char **argv)
   bool triangulatePolygonsMode = false;
   std::string inputSchemaFile;
   std::string outputVtkFile;
+  std::string serializedPropertiesArrayName;
 
   vtksys::CommandLineArguments arg;
   arg.Initialize(argc, argv);
@@ -47,6 +48,9 @@ int TestGeoJSON(int argc, char **argv)
                   &inputSchemaFile, "json-schema file specifying feature properties");
   arg.AddArgument("-o", vtksys::CommandLineArguments::NO_ARGUMENT,
                   &outlinePolygonsMode, "flag to set OutlinePolygons mode");
+  arg.AddArgument("-p", vtksys::CommandLineArguments::SPACE_ARGUMENT,
+                  &serializedPropertiesArrayName,
+                  "name of cell data array for storing serialized properties");
   arg.AddArgument("-s", vtksys::CommandLineArguments::NO_ARGUMENT,
                   &stringInputMode, "flag to load file as string before parsing");
   arg.AddArgument("-t", vtksys::CommandLineArguments::NO_ARGUMENT,
@@ -97,6 +101,11 @@ int TestGeoJSON(int argc, char **argv)
   // Set triangulate and outline modes
   reader->SetOutlinePolygons(outlinePolygonsMode);
   reader->SetTriangulatePolygons(triangulatePolygonsMode);
+  if (serializedPropertiesArrayName.size() > 0)
+    {
+    reader->SetSerializedPropertiesArrayName(
+      serializedPropertiesArrayName.c_str());
+    }
 
   // Process schema
   if (!inputSchemaFile.empty())

--- a/vtkGeoJSONReader.h
+++ b/vtkGeoJSONReader.h
@@ -73,6 +73,12 @@ public:
   vtkBooleanMacro(OutlinePolygons, bool);
 
   // Description:
+  // Set/get name of data array for serialized GeoJSON "properties" node.
+  // If specified, data will be stored as vtkCellData/vtkStringArray.
+  vtkSetStringMacro(SerializedPropertiesArrayName);
+  vtkGetStringMacro(SerializedPropertiesArrayName);
+
+  // Description:
   // Specify feature property to read in with geometry objects
   // Note that defaultValue specifies both type & value
   void AddFeatureProperty(const char *name, vtkVariant& typeAndDefaultValue);
@@ -110,6 +116,7 @@ protected:
   bool StringInputMode;
   bool TriangulatePolygons;
   bool OutlinePolygons;
+  char *SerializedPropertiesArrayName;
 
 private:
   class GeoJSONReaderInternals;


### PR DESCRIPTION
This adds an option to vtkGeoJSONReader to attach a vtkStringArray to the output vtkPolyData, representing the GeoJSON "properties" object attached to each GeoJSON feature in the input.
